### PR TITLE
Add deprecation notice to routing and swap-and-add-liquidity

### DIFF
--- a/v3-sdk/routing/README.md
+++ b/v3-sdk/routing/README.md
@@ -1,5 +1,9 @@
 # Routing
 
+## Deprecated
+
+This example no longer works with recent versions of the smart order router package and can be considered deprecated.
+
 ## Overview
 
 This is an example of finding an ideal swapping route that includes running against mainnet, locally, and using a wallet connection.

--- a/v3-sdk/swap-and-add-liquidity/README.md
+++ b/v3-sdk/swap-and-add-liquidity/README.md
@@ -1,5 +1,9 @@
 # Swap and Add Liquidity
 
+## Deprecated
+
+This example no longer works with recent versions of the smart order router package and can be considered deprecated.
+
 ## Overview
 
 This is an example that demonstrates how to swap between currencies and add those currencies to a liquidity pool in the same transaction that includes running against mainnet, locally, and using a wallet connection.


### PR DESCRIPTION
The smart order router package has several bugs since end of 2023 and can no longer be used for the routing and swap and add liquidity examples. Added a deprecation notice to the readme of both examples.