### PR TITLE
Fix smart-order-router version in swap-and-add-liquidity example

### DIFF
--- a/v3-sdk/swap-and-add-liquidity/package.json
+++ b/v3-sdk/swap-and-add-liquidity/package.json
@@ -8,7 +8,7 @@
     "@types/react-dom": "^18.0.0",
     "@uniswap/sdk-core": "npm:@uniswapfoundation/sdk-core@^5.0.0",
     "@uniswap/v3-sdk": "npm:@uniswapfoundation/v3-sdk@^4.0.2",
-    "@uniswap/smart-order-router": "npm:@uniswapfoundation/smart-order-router@^3.19.0",
+    "@uniswap/smart-order-router": "npm:@uniswapfoundation/smart-order-router@^3.20.5",
     "ethers": "^5.7.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/v3-sdk/swap-and-add-liquidity/yarn.lock
+++ b/v3-sdk/swap-and-add-liquidity/yarn.lock
@@ -2596,15 +2596,24 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@uniswap/default-token-list@npm:@uniswapfoundation/default-token-list@^11.10.0":
-  version "11.10.0"
-  resolved "https://registry.yarnpkg.com/@uniswapfoundation/default-token-list/-/default-token-list-11.10.0.tgz#f87340c620c90375b82a63f1e66cb6f73de7237f"
-  integrity sha512-j4tBhVgwzwUKotokBvL4tD9aUwRXQjW/Fc9/thki1ofMAv7PYPM9+LxOQrsZnUfTNziAExOALYPVpIiVPi4xdg==
+"@uniswap/default-token-list@npm:@uniswapfoundation/default-token-list@^11.11.1":
+  version "11.11.1"
+  resolved "https://registry.yarnpkg.com/@uniswapfoundation/default-token-list/-/default-token-list-11.11.1.tgz#c17d4ef18c556e76dd3ba8822ce1cdf9ba128f2f"
+  integrity sha512-K/f+WCqcTyLRL+r2HE3Ac7kNvIGPQ8U+n/EPZmG40qQMSPz1n7HgBQ3grb/5HNXYGz3KxXAib8Nd7IG5hbV09Q==
 
 "@uniswap/lib@^4.0.1-alpha":
   version "4.0.1-alpha"
   resolved "https://registry.yarnpkg.com/@uniswap/lib/-/lib-4.0.1-alpha.tgz#2881008e55f075344675b3bca93f020b028fbd02"
   integrity sha512-f6UIliwBbRsgVLxIaBANF6w09tYqc6Y/qXdsrbEmXHyFA7ILiKrIwRFXe1yOg8M3cksgVsO9N7yuL2DdCGQKBA==
+
+"@uniswap/narwhal@npm:@uniswap/universal-router@^1.0.1":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/universal-router/-/universal-router-1.6.0.tgz#3d7372e98a0303c70587802ee6841b8b6b42fc6f"
+  integrity sha512-Gt0b0rtMV1vSrgXY3vz5R1RCZENB+rOkbOidY9GvcXrK1MstSrQSOAc+FCr8FSgsDhmRAdft0lk5YUxtM9i9Lg==
+  dependencies:
+    "@openzeppelin/contracts" "4.7.0"
+    "@uniswap/v2-core" "1.0.1"
+    "@uniswap/v3-core" "1.0.0"
 
 "@uniswap/permit2-sdk@^1.2.0":
   version "1.2.0"
@@ -2614,16 +2623,16 @@
     ethers "^5.3.1"
     tiny-invariant "^1.3.1"
 
-"@uniswap/router-sdk@npm:@uniswapfoundation/router-sdk@^1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@uniswapfoundation/router-sdk/-/router-sdk-1.8.0.tgz#6a9d58bcabcc385e5d1f28cfca08654089082b77"
-  integrity sha512-C3hDtpFog2RdFX9mNNRgCt6iQPJ9QtTdPpnWNbptSAhWoCk1Si7n95C2/rivcQtppe14y83MKcQ9U6QGaFiJww==
+"@uniswap/router-sdk@npm:@uniswapfoundation/router-sdk@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@uniswapfoundation/router-sdk/-/router-sdk-1.8.1.tgz#d8393349d0484ea45c802e8d40c31563d4c5153b"
+  integrity sha512-Mma/934MEDdmN5xJZMuA+2BM+6ecTTmcgdpzwdm19qNFheTDjNIZUUrR10OBquoyEA+OFG8aLQ3JaBegROUD+g==
   dependencies:
     "@ethersproject/abi" "^5.5.0"
     "@uniswap/sdk-core" "npm:@uniswapfoundation/sdk-core@^5.0.0"
     "@uniswap/swap-router-contracts" "^1.1.0"
-    "@uniswap/v2-sdk" "npm:@uniswapfoundation/v2-sdk@^4.0.0"
-    "@uniswap/v3-sdk" "npm:@uniswapfoundation/v3-sdk@^4.0.1"
+    "@uniswap/v2-sdk" "npm:@uniswapfoundation/v2-sdk@^4.0.1"
+    "@uniswap/v3-sdk" "npm:@uniswapfoundation/v3-sdk@^4.0.2"
 
 "@uniswap/sdk-core@npm:@uniswapfoundation/sdk-core@^5.0.0":
   version "5.0.0"
@@ -2637,21 +2646,21 @@
     tiny-invariant "^1.1.0"
     toformat "^2.0.0"
 
-"@uniswap/smart-order-router@npm:@uniswapfoundation/smart-order-router@^3.19.0":
-  version "3.19.0"
-  resolved "https://registry.yarnpkg.com/@uniswapfoundation/smart-order-router/-/smart-order-router-3.19.0.tgz#6f25ff84bd1b947794aa81fafc5686a2936cf26b"
-  integrity sha512-t6/EZl+bJ4Kdzk42NnUF/ZmpVgIbHqu9XYcxbJhKVxlNC5HaSwGED2cHgezCeOCF9yTfaHAsES676lkbNGQLsA==
+"@uniswap/smart-order-router@npm:@uniswapfoundation/smart-order-router@^3.20.5":
+  version "3.20.5"
+  resolved "https://registry.yarnpkg.com/@uniswapfoundation/smart-order-router/-/smart-order-router-3.20.5.tgz#d087c793e3a2c5ab08b23b49299a11618bd276c7"
+  integrity sha512-FXXLXtizYXKD5ducu9hFlsFWD4hq4m/08RQZu20ykat1HbW8RnI0+hdPluXDvj2fDvuCkc+dLKnFXIFca8GyRQ==
   dependencies:
-    "@uniswap/default-token-list" "npm:@uniswapfoundation/default-token-list@^11.10.0"
+    "@uniswap/default-token-list" "npm:@uniswapfoundation/default-token-list@^11.11.1"
+    "@uniswap/narwhal" "npm:@uniswap/universal-router@^1.0.1"
     "@uniswap/permit2-sdk" "^1.2.0"
-    "@uniswap/router-sdk" "npm:@uniswapfoundation/router-sdk@^1.8.0"
+    "@uniswap/router-sdk" "npm:@uniswapfoundation/router-sdk@^1.8.1"
     "@uniswap/sdk-core" "npm:@uniswapfoundation/sdk-core@^5.0.0"
     "@uniswap/swap-router-contracts" "^1.3.0"
     "@uniswap/token-lists" "^1.0.0-beta.31"
-    "@uniswap/universal-router" "^1.0.1"
-    "@uniswap/universal-router-sdk" "npm:@uniswapfoundation/universal-router-sdk@^2.1.0"
-    "@uniswap/v2-sdk" "npm:@uniswapfoundation/v2-sdk@^4.0.0"
-    "@uniswap/v3-sdk" "npm:@uniswapfoundation/v3-sdk@^4.0.1"
+    "@uniswap/universal-router-sdk" "npm:@uniswapfoundation/universal-router-sdk@^2.1.2"
+    "@uniswap/v2-sdk" "npm:@uniswapfoundation/v2-sdk@^4.0.1"
+    "@uniswap/v3-sdk" "npm:@uniswapfoundation/v3-sdk@^4.0.2"
     async-retry "^1.3.1"
     await-timeout "^1.1.1"
     axios "^0.21.1"
@@ -2682,21 +2691,21 @@
   resolved "https://registry.yarnpkg.com/@uniswap/token-lists/-/token-lists-1.0.0-beta.33.tgz#966ba96c9ccc8f0e9e09809890b438203f2b1911"
   integrity sha512-JQkXcpRI3jFG8y3/CGC4TS8NkDgcxXaOQuYW8Qdvd6DcDiIyg2vVYCG9igFEzF0G6UvxgHkBKC7cWCgzZNYvQg==
 
-"@uniswap/universal-router-sdk@npm:@uniswapfoundation/universal-router-sdk@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@uniswapfoundation/universal-router-sdk/-/universal-router-sdk-2.1.0.tgz#5f89bbbb82d314f38d40ef3dac030d4a7f117112"
-  integrity sha512-iv1Ll2m0xDiyNdKmssRkVBuDN5oM8Tc4CbsnBIg9qgDVnJ2P2Y7TCUP25hCwdqtHXln1Tp+ZFy3OJp0DvnLsrA==
+"@uniswap/universal-router-sdk@npm:@uniswapfoundation/universal-router-sdk@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@uniswapfoundation/universal-router-sdk/-/universal-router-sdk-2.1.2.tgz#4d1fc74f30a8201a8ba5e59be95a421e5c56b683"
+  integrity sha512-KxCWlKth1I3skqfpxZkdSFObEbiOQhTl8bbXt8nfhczKZEHU5TeANVhIm0HDQEtBcRoJZfPvfs+KcR/tohwAQA==
   dependencies:
     "@uniswap/permit2-sdk" "^1.2.0"
-    "@uniswap/router-sdk" "npm:@uniswapfoundation/router-sdk@^1.8.0"
+    "@uniswap/router-sdk" "npm:@uniswapfoundation/router-sdk@^1.8.1"
     "@uniswap/sdk-core" "npm:@uniswapfoundation/sdk-core@^5.0.0"
     "@uniswap/universal-router" "1.5.1"
-    "@uniswap/v2-sdk" "npm:@uniswapfoundation/v2-sdk@^4.0.0"
-    "@uniswap/v3-sdk" "npm:@uniswapfoundation/v3-sdk@^4.0.1"
+    "@uniswap/v2-sdk" "npm:@uniswapfoundation/v2-sdk@^4.0.1"
+    "@uniswap/v3-sdk" "npm:@uniswapfoundation/v3-sdk@^4.0.2"
     bignumber.js "^9.0.2"
     ethers "^5.3.1"
 
-"@uniswap/universal-router@1.5.1", "@uniswap/universal-router@^1.0.1":
+"@uniswap/universal-router@1.5.1":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@uniswap/universal-router/-/universal-router-1.5.1.tgz#2ce832485eb85093b0cb94a53be20661e1aece70"
   integrity sha512-+htTC/nHQXKfY/c+9C1XHMRs7Jz0bX9LQfYn9Hb7WZKZ/YHWhOsCZQylYhksieLYTRam5sQheow747hOZ+QpZQ==
@@ -2710,10 +2719,10 @@
   resolved "https://registry.yarnpkg.com/@uniswap/v2-core/-/v2-core-1.0.1.tgz#af8f508bf183204779938969e2e54043e147d425"
   integrity sha512-MtybtkUPSyysqLY2U210NBDeCHX+ltHt3oADGdjqoThZaFRDKwM6k1Nb3F0A3hk5hwuQvytFWhrWHOEq6nVJ8Q==
 
-"@uniswap/v2-sdk@npm:@uniswapfoundation/v2-sdk@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@uniswapfoundation/v2-sdk/-/v2-sdk-4.0.0.tgz#c0a4a9ffa36e398f270e86a78945562c546739f1"
-  integrity sha512-V+/zRdIkNLBLc7QsaV2YN604MoCZTjUfO6WeLtQoditJtrUrbNZgnltuHsgn8GfuynyMPVjknYr2xmllIHnuPg==
+"@uniswap/v2-sdk@npm:@uniswapfoundation/v2-sdk@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@uniswapfoundation/v2-sdk/-/v2-sdk-4.0.1.tgz#15ca02fdcdfd3046c3b6a25e3260a59c38f58741"
+  integrity sha512-nXbHzSnMlFQHaLMGVi2bFSxyHUlO8qrVoXyqG1fuGfLDOn+mNwf1bF+lesOSLq0cDaWrNJPs9q1Ri3Z3hwzTkg==
   dependencies:
     "@ethersproject/address" "^5.0.0"
     "@ethersproject/solidity" "^5.0.0"
@@ -2741,22 +2750,6 @@
     "@uniswap/v2-core" "^1.0.1"
     "@uniswap/v3-core" "^1.0.0"
     base64-sol "1.0.1"
-
-"@uniswap/v3-sdk@npm:@uniswapfoundation/v3-sdk@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@uniswapfoundation/v3-sdk/-/v3-sdk-4.0.1.tgz#3c296be898700937ca8c1de5967b3259e7f49d55"
-  integrity sha512-U9BH+gSp92uVNU9g+OUBaEAO/bnIqaSqU6qistzSDNZla3r65zapIhvEFbo3NxmkjoRdmqFF3WwYX4JsB0qvNg==
-  dependencies:
-    "@ethersproject/abi" "^5.0.12"
-    "@ethersproject/solidity" "^5.0.9"
-    "@uniswap/sdk-core" "npm:@uniswapfoundation/sdk-core@^5.0.0"
-    "@uniswap/swap-router-contracts" "^1.2.1"
-    "@uniswap/v3-periphery" "^1.1.1"
-    "@uniswap/v3-staker" "1.0.2"
-    ethers "^5.7.2"
-    ethers-multicall "^0.2.3"
-    tiny-invariant "^1.1.0"
-    tiny-warning "^1.0.3"
 
 "@uniswap/v3-sdk@npm:@uniswapfoundation/v3-sdk@^4.0.2":
   version "4.0.2"
@@ -4977,14 +4970,7 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
-ethers-multicall@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/ethers-multicall/-/ethers-multicall-0.2.3.tgz#872b5ad7d6b5d4d7f2960c33bf36bd46d034ac41"
-  integrity sha512-RaWQuLy+HzeKOibptlc9RZ6j7bT1H6VnkdAKTHiLx2t/lpyfS2ckXHdQhhRbCaXNc1iu6CgoisgMejxKHg84tg==
-  dependencies:
-    ethers "^5.0.0"
-
-ethers@^5.0.0, ethers@^5.3.1, ethers@^5.7.2:
+ethers@^5.3.1, ethers@^5.7.2:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
   integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==


### PR DESCRIPTION
Socket security had some issues with the older smart-order-router version in the swap-and-add-liquidity example. Better to use the most recent anyways.